### PR TITLE
Add normalization and scaling features

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,23 +46,25 @@ This library is suitable for **both beginners and advanced data scientists** who
    - **Label Encoding** by default.
    - Optional **One-Hot Encoding** via `encoding_strategy="onehot"`.
 
-3. **Feature Scaling**  
-   - Uses **StandardScaler** by default (mean=0, variance=1).  
-   - Future enhancements include **MinMaxScaler**, **RobustScaler**, or **custom scalers**.
+3. **Feature Scaling**
+   - Uses **StandardScaler** by default (mean=0, variance=1).
+   - Optionally switch to **MinMaxScaler** via `scaling_strategy="minmax"`.
 
-4. **Target Separation for Classification**  
+4. **Target Separation for Classification**
    - Automatically separates the target column from the dataset, simplifying the modeling pipeline.
 
-5. **Outlier Detection (Planned)**  
+5. **Column Normalization Utility**
+   - Quickly scale numeric columns to the `[0, 1]` range with `normalize_columns()`.
+6. **Outlier Detection (Planned)**
    - Will provide automated detection and handling using techniques like **IQR**, **z-score**, or **Isolation Forest**.
 
-6. **Basic Feature Engineering (Planned)**  
+7. **Basic Feature Engineering (Planned)**
    - Transformations like logarithmic scaling, polynomial features, and feature interactions.
 
-7. **Customization Options**  
+8. **Customization Options**
    - Upcoming versions will allow specifying advanced imputation methods, encoder types, and scaling techniques.
 
-8. **Ease of Use**  
+9. **Ease of Use**
    - Designed to be **beginner-friendly** yet **highly flexible** for experienced users.  
    - Simple function calls for straightforward workflows.
 
@@ -110,7 +112,7 @@ Here’s a minimal example to show how easy it is to get started:
 
 ```python
 import pandas as pd
-from auto_data_preprocessor import AutoDataPreprocessor
+from auto_preprocessor import DataPreprocessor
 
 # Sample dataset
 data = {
@@ -123,7 +125,7 @@ data = {
 df = pd.DataFrame(data)
 
 # Initialize the preprocessor
-preprocessor = AutoDataPreprocessor()
+preprocessor = DataPreprocessor(scaling_strategy="minmax")
 
 # Preprocess the data
 X, y = preprocessor.preprocess(df, target_column="purchased")
@@ -165,7 +167,7 @@ Sometimes your dataset has a different target column name, such as `y` or `Class
 ```python
 df = pd.read_csv("path_to_csv.csv")  # your custom dataset
 
-preprocessor = AutoDataPreprocessor()
+preprocessor = DataPreprocessor()
 X, y = preprocessor.preprocess(df, target_column="Class")
 ```
 
@@ -192,7 +194,7 @@ print(f"Test Accuracy: {accuracy}")
 The default strategy is **mean imputation for numerical** and **most frequent for categorical** columns. In future releases, you’ll be able to specify:
 
 ```python
-preprocessor = AutoDataPreprocessor(
+preprocessor = DataPreprocessor(
     numerical_imputation_strategy='median',
     categorical_imputation_strategy='mode',
     fill_values={'age': 30, 'income': 50000}  # custom fill values

--- a/auto_preprocessor/__init__.py
+++ b/auto_preprocessor/__init__.py
@@ -1,0 +1,20 @@
+"""Convenience imports for the auto_preprocessor package."""
+
+from .data_cleaning import (
+    remove_outliers,
+    handle_missing_values,
+    remove_duplicate_rows,
+    normalize_columns,
+)
+from .feature_engineering import apply_pca
+from .data_preprocessor import DataPreprocessor
+
+__all__ = [
+    "remove_outliers",
+    "handle_missing_values",
+    "remove_duplicate_rows",
+    "normalize_columns",
+    "apply_pca",
+    "DataPreprocessor",
+]
+

--- a/auto_preprocessor/data_cleaning.py
+++ b/auto_preprocessor/data_cleaning.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+from sklearn.preprocessing import MinMaxScaler
 
 def remove_outliers(df, columns, method="zscore", threshold=3):
     if method == "zscore":
@@ -31,3 +32,28 @@ def handle_missing_values(df, strategy="mean", columns=None):
 def remove_duplicate_rows(df):
     """Remove duplicate rows from a DataFrame and reset index."""
     return df.drop_duplicates().reset_index(drop=True)
+
+
+def normalize_columns(df, columns=None):
+    """Normalize selected numeric columns to the range [0, 1].
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input DataFrame whose columns will be normalized.
+    columns : list of str, optional
+        Specific column names to normalize. If ``None`` (default), all numeric
+        columns are normalized.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with normalized columns.
+    """
+
+    if columns is None:
+        columns = df.select_dtypes(include=["number"]).columns
+
+    scaler = MinMaxScaler()
+    df[columns] = scaler.fit_transform(df[columns])
+    return df

--- a/auto_preprocessor/data_preprocessor.py
+++ b/auto_preprocessor/data_preprocessor.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from sklearn.preprocessing import StandardScaler, LabelEncoder, OneHotEncoder
+from sklearn.preprocessing import StandardScaler, MinMaxScaler, LabelEncoder, OneHotEncoder
 from sklearn.impute import SimpleImputer
 
 
@@ -11,14 +11,15 @@ class DataPreprocessor:
     - Automatic detection of categorical and numerical columns
     - Missing value imputation (default strategies)
     - Label encoding for categorical variables
-    - Standard scaling for numerical features
+    - Feature scaling for numerical columns (standard or min-max)
     - Target column separation
     """
 
     def __init__(self,
                  numerical_imputer_strategy="mean",
                  categorical_imputer_strategy="most_frequent",
-                 encoding_strategy="label"):
+                 encoding_strategy="label",
+                 scaling_strategy="standard"):
         """
         Initializes the preprocessing pipeline.
 
@@ -30,10 +31,17 @@ class DataPreprocessor:
         - encoding_strategy: str, default="label"
               Encoding method for categorical variables. Supported values are
               "label" and "onehot".
+        - scaling_strategy: str, default="standard"
+              Scaling method for numerical features. Supported values are
+              "standard" and "minmax".
         """
         self.encoding_strategy = encoding_strategy
 
-        self.scaler = StandardScaler()
+        self.scaling_strategy = scaling_strategy
+        if scaling_strategy == "minmax":
+            self.scaler = MinMaxScaler()
+        else:
+            self.scaler = StandardScaler()
         self.label_encoders = {}
         self.onehot_encoder = None
         self.num_imputer = SimpleImputer(strategy=numerical_imputer_strategy)

--- a/tests/test_data_cleaning.py
+++ b/tests/test_data_cleaning.py
@@ -1,6 +1,10 @@
 import pandas as pd
-from auto_preprocessor.data_cleaning import remove_outliers, handle_missing_values
-from auto_preprocessor.data_cleaning import remove_duplicate_rows
+from auto_preprocessor.data_cleaning import (
+    remove_outliers,
+    handle_missing_values,
+    remove_duplicate_rows,
+    normalize_columns,
+)
 
 def test_remove_outliers():
     data = {
@@ -28,3 +32,11 @@ def test_remove_duplicate_rows():
     df = pd.DataFrame(data)
     deduped_df = remove_duplicate_rows(df)
     assert len(deduped_df) == 2
+
+
+def test_normalize_columns():
+    data = {"value": [0, 5, 10]}
+    df = pd.DataFrame(data)
+    norm_df = normalize_columns(df)
+    assert norm_df["value"].min() == 0
+    assert norm_df["value"].max() == 1

--- a/tests/test_data_preprocessor.py
+++ b/tests/test_data_preprocessor.py
@@ -26,3 +26,16 @@ def test_preprocess_onehot_encoding():
     X, y = preprocessor.preprocess(df, target_column="purchased")
     assert "gender_Female" in X.columns
     assert "gender_Male" in X.columns
+
+
+def test_preprocess_minmax_scaling():
+    data = {
+        "age": [20, 30, 40],
+        "income": [50, 100, 150],
+        "purchased": [0, 1, 0],
+    }
+    df = pd.DataFrame(data)
+    preprocessor = DataPreprocessor(scaling_strategy="minmax")
+    X, _ = preprocessor.preprocess(df, target_column="purchased")
+    assert X["age"].min() == 0
+    assert X["age"].max() == 1


### PR DESCRIPTION
## Summary
- add `normalize_columns` helper for min-max scaling
- expose library components in `auto_preprocessor.__init__`
- add optional `scaling_strategy` argument to `DataPreprocessor`
- document normalization utility and scaling option in README
- update unit tests for new features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688a404c6c74833382c3c4a81a793028